### PR TITLE
Adjust Github login scope

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import styles from "./footer.module.css"
-import { dependencies } from "../package.json"
+import packageInfo from "../package.json"
 
 export default function Footer() {
   return (
@@ -22,7 +22,7 @@ export default function Footer() {
           </Link>
         </li>
         <li className={styles.navItem}>
-          <em>next-auth@{dependencies["next-auth"]}</em>
+          <em>next-auth@{packageInfo.dependencies["next-auth"]}</em>
         </li>
       </ul>
     </footer>

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -31,6 +31,8 @@ export default NextAuth({
     Providers.GitHub({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
+      // https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
+      scope: "read:user",
     }),
     Providers.Google({
       clientId: process.env.GOOGLE_ID,


### PR DESCRIPTION
The following PR addresses the following issues:

- Adjust Github login scope to read-only user data as per [this issue](https://github.com/nextauthjs/next-auth/issues/2224)
- Resolve a warning in `components/footer.tsx` about importing named export "dependencies". 

The actual warning message is:

```
Should not import the named export 'dependencies'.'next-auth' (imported as 'dependencies') from default-exporting module (only default export is available soon)
```

A corresponding SO thread can be found [here](https://stackoverflow.com/questions/64993118/error-should-not-import-the-named-export-version-imported-as-version)

