### PR TITLE
feat: migrate to v4

### DIFF
--- a/components/access-denied.tsx
+++ b/components/access-denied.tsx
@@ -1,4 +1,4 @@
-import { signIn } from 'next-auth/client'
+import { signIn } from 'next-auth/react'
 
 export default function AccessDenied () {
   return (

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -7,7 +7,7 @@ import styles from "./header.module.css"
 // rendering, and avoids any flash incorrect content on initial page load.
 export default function Header() {
   const { data: session, status } = useSession()
-	const loading = status === 'loading'
+  const loading = status === 'loading'
 
   return (
     <header>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link"
-import { signIn, signOut, useSession } from "next-auth/client"
+import { signIn, signOut, useSession } from "next-auth/react"
 import styles from "./header.module.css"
 
 // The approach used in this component shows how to built a sign in and sign out
 // component that works on pages which support both client and server side
 // rendering, and avoids any flash incorrect content on initial page load.
 export default function Header() {
-  const [session, loading] = useSession()
+  const { data: session, status } = useSession()
+	const loading = status === 'loading'
 
   return (
     <header>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "next": "^11.0.0",
-    "next-auth": "4.0.0-beta.2",
+    "next-auth": "^4.0.0-beta.7",
     "nodemailer": "^6.6.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "next": "^11.0.0",
-    "next-auth": "^4.0.0-next.20",
+    "next-auth": "^4.0.0-next.24",
     "nodemailer": "^6.6.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "next": "^11.0.0",
-    "next-auth": "^4.0.0-beta.1",
+    "next-auth": "4.0.0-beta.1",
     "nodemailer": "^6.6.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "next": "^11.0.0",
-    "next-auth": "latest",
+    "next-auth": "^4.0.0-next.20",
+    "nodemailer": "^6.6.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "sqlite3": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "next": "^11.0.0",
-    "next-auth": "^4.0.0-beta.7",
+    "next-auth": "4.0.0-beta.7",
     "nodemailer": "^6.6.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "next": "^11.0.0",
-    "next-auth": "^4.0.0-next.24",
+    "next-auth": "^4.0.0-beta.1",
     "nodemailer": "^6.6.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "next": "^11.0.0",
-    "next-auth": "4.0.0-beta.1",
+    "next-auth": "4.0.0-beta.2",
     "nodemailer": "^6.6.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "next-auth": "^4.0.1",
     "nodemailer": "^6.6.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "sqlite3": "^5.0.2"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@types/node": "^15.12.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "next": "^11.0.0",
-    "next-auth": "4.0.0-beta.7",
+    "next-auth": "^4.0.1",
     "nodemailer": "^6.6.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "author": "Lluis Agusti <lluis@hey.com>",
   "contributors": [
     "Balázs Orbán <info@balazsorban.com>",
-    "Iain Collins <me@iaincollins.com>"
+    "Iain Collins <me@iaincollins.com>",
+    "Nico Domino <yo@ndo.dev>"
   ],
   "license": "ISC",
   "prettier": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,32 +1,32 @@
-import { Provider } from "next-auth/client"
+import { SessionProvider } from "next-auth/react"
 import type { AppProps } from "next/app"
 import "./styles.css"
 
-// Use the <Provider> to improve performance and allow components that call
+// Use the <SessionProvider> to improve performance and allow components that call
 // `useSession()` anywhere in your application to access the `session` object.
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <Provider
+    <SessionProvider
       // Provider options are not required but can be useful in situations where
       // you have a short session maxAge time. Shown here with default values.
       options={{
-        // Client Max Age controls how often the useSession in the client should
+        // Stale Time controls how often the useSession in the client should
         // contact the server to sync the session state. Value in seconds.
         // e.g.
         // * 0  - Disabled (always use cache value)
         // * 60 - Sync session state with server if it's older than 60 seconds
-        clientMaxAge: 0,
-        // Keep Alive tells windows / tabs that are signed in to keep sending
+        staleTime: 0,
+        // Refetch Interval tells windows / tabs that are signed in to keep sending
         // a keep alive request (which extends the current session expiry) to
         // prevent sessions in open windows from expiring. Value in seconds.
         //
         // Note: If a session has expired when keep alive is triggered, all open
         // windows / tabs will be updated to reflect the user is signed out.
-        keepAlive: 0,
+        refetchInterval: 0,
       }}
       session={pageProps.session}
     >
       <Component {...pageProps} />
-    </Provider>
+    </SessionProvider>
   )
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,21 +9,6 @@ export default function App({ Component, pageProps }: AppProps) {
     <SessionProvider
       // Provider options are not required but can be useful in situations where
       // you have a short session maxAge time. Shown here with default values.
-      options={{
-        // Stale Time controls how often the useSession in the client should
-        // contact the server to sync the session state. Value in seconds.
-        // e.g.
-        // * 0  - Disabled (always use cache value)
-        // * 60 - Sync session state with server if it's older than 60 seconds
-        staleTime: 0,
-        // Refetch Interval tells windows / tabs that are signed in to keep sending
-        // a keep alive request (which extends the current session expiry) to
-        // prevent sessions in open windows from expiring. Value in seconds.
-        //
-        // Note: If a session has expired when keep alive is triggered, all open
-        // windows / tabs will be updated to reflect the user is signed out.
-        refetchInterval: 0,
-      }}
       session={pageProps.session}
     >
       <Component {...pageProps} />

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -67,8 +67,8 @@ export default NextAuth({
   session: {
     // Use JSON Web Tokens for session instead of database sessions.
     // This option can be used with or without a database for users/accounts.
-    // Note: `jwt` is automatically set to `true` if no database is specified.
-    jwt: true,
+    // Note: `strategy` should be set to 'jwt' if no database is used.
+    strategy: 'jwt'
 
     // Seconds - How long until an idle session expires and is no longer valid.
     // maxAge: 30 * 24 * 60 * 60, // 30 days

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,16 +1,22 @@
 import NextAuth from "next-auth"
-import Providers from "next-auth/providers"
+import EmailProvider from "next-auth/providers/email"
+import AppleProvider from "next-auth/providers/apple"
+import Auth0Provider from "next-auth/providers/auth0"
+import FacebookProvider from "next-auth/providers/facebook"
+import GithubProvider from "next-auth/providers/github"
+import GoogleProvider from "next-auth/providers/google"
+import TwitterProvider from "next-auth/providers/twitter"
 
 // For more information on each option (and a full list of options) go to
 // https://next-auth.js.org/configuration/options
 export default NextAuth({
   // https://next-auth.js.org/configuration/providers
   providers: [
-    Providers.Email({
+    EmailProvider({
       server: process.env.EMAIL_SERVER,
       from: process.env.EMAIL_FROM,
     }),
-    Providers.Apple({
+    AppleProvider({
       clientId: process.env.APPLE_ID,
       clientSecret: {
         appleId: process.env.APPLE_ID,
@@ -19,26 +25,26 @@ export default NextAuth({
         keyId: process.env.APPLE_KEY_ID,
       },
     }),
-    Providers.Auth0({
+    Auth0Provider({
       clientId: process.env.AUTH0_ID,
       clientSecret: process.env.AUTH0_SECRET,
       domain: process.env.AUTH0_DOMAIN,
     }),
-    Providers.Facebook({
+    FacebookProvider({
       clientId: process.env.FACEBOOK_ID,
       clientSecret: process.env.FACEBOOK_SECRET,
     }),
-    Providers.GitHub({
+    GitHubProvider({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
       // https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
       scope: "read:user",
     }),
-    Providers.Google({
+    GoogleProvider({
       clientId: process.env.GOOGLE_ID,
       clientSecret: process.env.GOOGLE_SECRET,
     }),
-    Providers.Twitter({
+    TwitterProvider({
       clientId: process.env.TWITTER_ID,
       clientSecret: process.env.TWITTER_SECRET,
     }),

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -28,6 +28,7 @@ export default NextAuth({
     Auth0Provider({
       clientId: process.env.AUTH0_ID,
       clientSecret: process.env.AUTH0_SECRET,
+      // @ts-ignore
       domain: process.env.AUTH0_DOMAIN,
     }),
     FacebookProvider({
@@ -38,6 +39,7 @@ export default NextAuth({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
       // https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
+      // @ts-ignore
       scope: "read:user",
     }),
     GoogleProvider({

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,30 +1,30 @@
 import NextAuth from "next-auth"
-import EmailProvider from "next-auth/providers/email"
-import AppleProvider from "next-auth/providers/apple"
 import Auth0Provider from "next-auth/providers/auth0"
 import FacebookProvider from "next-auth/providers/facebook"
 import GithubProvider from "next-auth/providers/github"
 import GoogleProvider from "next-auth/providers/google"
 import TwitterProvider from "next-auth/providers/twitter"
+// import EmailProvider from "next-auth/providers/email"
+// import AppleProvider from "next-auth/providers/apple"
 
 // For more information on each option (and a full list of options) go to
 // https://next-auth.js.org/configuration/options
 export default NextAuth({
   // https://next-auth.js.org/configuration/providers
   providers: [
-    EmailProvider({
-      server: process.env.EMAIL_SERVER,
-      from: process.env.EMAIL_FROM,
-    }),
-    AppleProvider({
-      clientId: process.env.APPLE_ID,
-      clientSecret: {
-        appleId: process.env.APPLE_ID,
-        teamId: process.env.APPLE_TEAM_ID,
-        privateKey: process.env.APPLE_PRIVATE_KEY,
-        keyId: process.env.APPLE_KEY_ID,
-      },
-    }),
+    // EmailProvider({
+    //   server: process.env.EMAIL_SERVER,
+    //   from: process.env.EMAIL_FROM,
+    // }),
+    // AppleProvider({
+    //   clientId: process.env.APPLE_ID,
+    //   clientSecret: {
+    //     appleId: process.env.APPLE_ID,
+    //     teamId: process.env.APPLE_TEAM_ID,
+    //     privateKey: process.env.APPLE_PRIVATE_KEY,
+    //     keyId: process.env.APPLE_KEY_ID,
+    //   },
+    // }),
     Auth0Provider({
       clientId: process.env.AUTH0_ID,
       clientSecret: process.env.AUTH0_SECRET,

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -102,10 +102,10 @@ export default NextAuth({
   // when an action is performed.
   // https://next-auth.js.org/configuration/callbacks
   callbacks: {
-    // async signIn(user, account, profile) { return true },
-    // async redirect(url, baseUrl) { return baseUrl },
-    // async session(session, user) { return session },
-    // async jwt(token, user, account, profile, isNewUser) { return token }
+    // async signIn({ user, account, profile, email, credentials }) { return true },
+    // async redirect({ url, baseUrl }) { return baseUrl },
+    // async session({ session, token, user }) { return session },
+    // async jwt({ token, user, account, profile, isNewUser }) { return token }
   },
 
   // Events are useful for logging

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -34,7 +34,7 @@ export default NextAuth({
       clientId: process.env.FACEBOOK_ID,
       clientSecret: process.env.FACEBOOK_SECRET,
     }),
-    GitHubProvider({
+    GithubProvider({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
       // https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
@@ -55,7 +55,7 @@ export default NextAuth({
   // Notes:
   // * You must install an appropriate node_module for your database
   // * The Email provider requires a database (OAuth providers do not)
-  database: process.env.DATABASE_URL,
+  // database: process.env.DATABASE_URL,
 
   // The secret should be set to a reasonably long random string.
   // It is used to sign cookies and to sign and encrypt JSON Web Tokens, unless
@@ -82,7 +82,7 @@ export default NextAuth({
   // https://next-auth.js.org/configuration/options#jwt
   jwt: {
     // A secret to use for key generation (you should set this explicitly)
-    // secret: 'INp8IvdIyeMcoGAgFGoA61DdBglwwSqnXJZkgz8PSnw',
+    secret: process.env.SECRET,
     // Set to true to use encryption (default: false)
     // encryption: true,
     // You can define your own encode/decode functions for signing and encryption

--- a/pages/api/examples/protected.ts
+++ b/pages/api/examples/protected.ts
@@ -1,5 +1,5 @@
 // This is an example of to protect an API route
-import { getSession } from "next-auth/client"
+import { getSession } from "next-auth/react"
 import type { NextApiRequest, NextApiResponse } from "next"
 
 export default async function protectedHandler(

--- a/pages/api/examples/session.ts
+++ b/pages/api/examples/session.ts
@@ -1,5 +1,5 @@
 // This is an example of how to access a session from an API route
-import { getSession } from "next-auth/client"
+import { getSession } from "next-auth/react"
 import type { NextApiRequest, NextApiResponse } from "next"
 
 export default async function session(

--- a/pages/protected.tsx
+++ b/pages/protected.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react'
-import { useSession } from 'next-auth/client'
+import { useSession } from 'next-auth/react'
 import Layout from '../components/layout'
 import AccessDenied from '../components/access-denied'
 
 export default function Page () {
-  const [ session, loading ] = useSession()
+  const { data: session, status } = useSession()
+	const loading = status === 'loading'
   const [ content , setContent ] = useState()
 
   // Fetch content from protected route

--- a/pages/protected.tsx
+++ b/pages/protected.tsx
@@ -5,7 +5,7 @@ import AccessDenied from '../components/access-denied'
 
 export default function Page () {
   const { data: session, status } = useSession()
-	const loading = status === 'loading'
+  const loading = status === 'loading'
   const [ content , setContent ] = useState()
 
   // Fetch content from protected route

--- a/pages/server.tsx
+++ b/pages/server.tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps } from "next"
 import type { Session } from "next-auth"
-import { useSession, getSession } from "next-auth/client"
+import { useSession, getSession } from "next-auth/react"
 import Layout from "../components/layout"
 
 export default function Page() {
@@ -8,7 +8,8 @@ export default function Page() {
   // populated on render without needing to go through a loading stage.
   // This is possible because of the shared context configured in `_app.js` that
   // is used by `useSession()`.
-  const [session, loading] = useSession()
+  const { data: session, status } = useSession()
+	const loading = status === 'loading'
 
   return (
     <Layout>

--- a/pages/server.tsx
+++ b/pages/server.tsx
@@ -9,7 +9,7 @@ export default function Page() {
   // This is possible because of the shared context configured in `_app.js` that
   // is used by `useSession()`.
   const { data: session, status } = useSession()
-	const loading = status === 'loading'
+  const loading = status === 'loading'
 
   return (
     <Layout>


### PR DESCRIPTION
Migrated everything that needs changed so far. 

I did, however, run into one console error regarding `jwt` that I wasn't sure about. Maybe I forgot to migrate something? 

For example, on the "API" page of the example app, which is supposed to print the current session and jwt info, I get the following in my node console:

```bash
event - build page: /api/examples/jwt
TypeError [ERR_INVALID_ARG_TYPE]: The "key" argument must be of type string or an instance of SecretKeyObject, ArrayBuffer, TypedArray, DataView, or Buffer. Received undefined
    at Object.hkdfSync (node:internal/crypto/hkdf:134:7)
    at hkdf (/opt/ndomino/next-auth-typescript-example/node_modules/next-auth/dist/lib/jwt.js:127:40)
    at getDerivedSigningKey (/opt/ndomino/next-auth-typescript-example/node_modules/next-auth/dist/lib/jwt.js:143:18)
    at decode (/opt/ndomino/next-auth-typescript-example/node_modules/next-auth/dist/lib/jwt.js:81:96)
    at getToken (/opt/ndomino/next-auth-typescript-example/node_modules/next-auth/dist/lib/jwt.js:109:12)
    at jwt (webpack-internal:///./pages/api/examples/jwt.ts:11:78)
    at Object.apiResolver (/opt/ndomino/next-auth-typescript-example/node_modules/next/dist/server/api-utils.js:101:15)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at async DevServer.handleApiRequest (/opt/ndomino/next-auth-typescript-example/node_modules/next/dist/server/next-server.js:760:9)
    at async Object.fn (/opt/ndomino/next-auth-typescript-example/node_modules/next/dist/server/next-server.js:651:37) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

On both the normal and typescript example apps btw.

Any idea whats going on there? Did I miss something in terms of the migration?

Obviously there will probably be a few more small things to change before this is really up to snuff for `v4.0.0` (final), but hopefully this takes care of most of the work and then we can merge this PR whenever the day comes :tada: 